### PR TITLE
Implement configurable index cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,13 @@ class MyChunkedStore(TimeseriesChunkStore):
     STORE_TZ   = 'Europe/Paris' # Chunking timezone (also timeseries output tz)
     STORE_FREQ   = '1h' # Timeseries storage frequency. (the store reindex input series but never resample)
     ALLOW_CLIENT_SERVER_SYNC = False # if True, enable the sync features
+    CACHED_INDEX_SIZE = 120  # max number of date indexes kept in cache
+```
+Use `CACHED_INDEX_SIZE` to tune the size of the LRU cache used when rebuilding
+indexes:
+```python
+class MyChunkedStore(TimeseriesChunkStore):
+    CACHED_INDEX_SIZE = 360
 ```
 The Custom fields are **strictly indexation axis** : you **must not** use them to store metadata or redundant data.
 

--- a/hostore/models/chunk_timeserie_store.py
+++ b/hostore/models/chunk_timeserie_store.py
@@ -196,6 +196,7 @@ class TimeseriesChunkStore(models.Model, metaclass=_TCSMeta):
     STORE_TZ   = 'Europe/Paris' # Chunking timezone
     STORE_FREQ   = '1h' # Timeseries storage frequency.
     ALLOW_CLIENT_SERVER_SYNC = False # if True, enable the sync features
+    CACHED_INDEX_SIZE = 120  # max size for cached date indexes
 
     _model_keys = None
     _model_td = None
@@ -240,6 +241,11 @@ class TimeseriesChunkStore(models.Model, metaclass=_TCSMeta):
             raise ValueError(
                 f"Invalid STORE_TZ {cls.STORE_TZ!r} for model {cls.__name__}"
             )
+
+        # wrap the index rebuild helper with an LRU cache sized per subclass
+        cls._cached_index = classmethod(
+            lru_cache(maxsize=cls.CACHED_INDEX_SIZE)(cls._cached_index.__func__)
+        )
 
     def delete(self, **kwargs):
         """ Soft-delete : conserve la ligne comme tombstone. """
@@ -723,7 +729,6 @@ class TimeseriesChunkStore(models.Model, metaclass=_TCSMeta):
         return cls._cached_index(row.start_ts, length)
 
     @classmethod
-    @lru_cache(maxsize=12*10)
     def _cached_index(cls, start_ts, length):
         return pd.date_range(
             start=pd.Timestamp(start_ts).tz_convert(cls.STORE_TZ),


### PR DESCRIPTION
## Summary
- allow subclasses to tune date index LRU cache via `CACHED_INDEX_SIZE`
- document cache option in README

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_688cd892ae8883318936691164b2760a