### PR TITLE
Add pagination to timeseries updates API

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ Main features
 | **Dense layout**                           | Each chunk is re-indexed on a regular grid (`STORE_FREQ`, `STORE_TZ`). |
 | **Smart upsert**                           | `set_ts(..., update=True)` merges with existing data via `combine_first`. |
 | **Bulk helpers**                           | `set_many_ts()` / `yield_many_ts()` for mass insert / streaming read. |
-| **Sync ready**                             | `list_updates`, `export_chunks`, `import_chunks` enable cheap client ↔ server replication. |
+| **Sync ready**                             | `updates_queryset`, `export_chunks`, `import_chunks` enable cheap client ↔ server replication. |
 | **REST scaffolding**                       | `TimeseriesChunkStoreSyncViewSet` + `TimeseriesChunkStoreSyncClient` give you plug-and-play API endpoints and a Python client. |
 
 Quick start

--- a/hostore/models/chunk_timeserie_store.py
+++ b/hostore/models/chunk_timeserie_store.py
@@ -557,7 +557,6 @@ class TimeseriesChunkStore(models.Model, metaclass=_TCSMeta):
         filters: dict | None = None,
         limit: int | None = None,
         offset: int | None = None,
-        qs_iterator_chunk_size: int = 200,
     ) -> list[dict]:
         """Convenience helper returning a list from ``updates_queryset``.
 
@@ -566,7 +565,6 @@ class TimeseriesChunkStore(models.Model, metaclass=_TCSMeta):
             filters: additional filters on the query.
             limit: maximum number of items to return.
             offset: number of items to skip from the beginning.
-            qs_iterator_chunk_size: size of queryset batch for iteration.
 
         Each dict contains::
             attrs       : full business key dict
@@ -583,7 +581,7 @@ class TimeseriesChunkStore(models.Model, metaclass=_TCSMeta):
             qs = qs[:limit]
 
         out = []
-        for row in qs.iterator(chunk_size=qs_iterator_chunk_size):
+        for row in qs:
             out.append({
                 "attrs": {k: row[k] for k in cls.get_model_keys()},
                 "chunk_index": row["chunk_index"],

--- a/hostore/tests/test_chunk_timeserie_sync.py
+++ b/hostore/tests/test_chunk_timeserie_sync.py
@@ -71,7 +71,7 @@ class SyncIntegrationTestCase(TransactionTestCase):
             # patch.object(requests, "post", self.req_client.post),
             # patch.object(requests, "put",  self.req_client.put),
         ):
-            return self.sync_client.pull(batch=20, filters=filters)
+            return self.sync_client.pull(batch=20, filters=filters, page_size=4)
 
     # --------------------------------------------------------------
     def test_full_sync_and_update(self):

--- a/hostore/utils/ts_sync.py
+++ b/hostore/utils/ts_sync.py
@@ -48,9 +48,7 @@ class ChunkIteratorPagination(LimitOffsetPagination):
 
         chunk_size = getattr(view, "qs_iterator_chunk_size", 200)
         return list(
-            queryset[self.offset : self.offset + self.limit].iterator(
-                chunk_size=chunk_size
-            )
+            queryset[self.offset : self.offset + self.limit]
         )
 
 
@@ -74,7 +72,6 @@ class TimeseriesChunkStoreSyncViewSet(viewsets.GenericViewSet):
 
     store_model: Type['TimeseriesChunkStore'] = None
     pagination_class = ChunkIteratorPagination
-    qs_iterator_chunk_size = 200
 
     # 1) /updates/?since=ISO
     @action(detail=False, methods=["get"])


### PR DESCRIPTION
## Summary
- support `limit`/`offset` pagination for chunk update listing
- iterate over update pages in `TimeseriesChunkStoreSyncClient.pull`
- document paginated `/updates/` endpoint in README

## Testing
- `DJANGO_SETTINGS_MODULE=holcstore.settings python manage.py test`

------
https://chatgpt.com/codex/tasks/task_b_689af96136e483319589b789cb2f187b